### PR TITLE
add nesting and loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ is set.
 of the `li` are set from the list items.
 
 ```html
-<ul sb-mark="list" sb-child="li"></ul>
+<ul>
+  <li sb-mark="list.#"></li>
+</ul>
 
 <script>
   data.list = ['Strawberry', 'Mulberry', 'Raspberry'];
@@ -191,12 +193,11 @@ of the `li` are set from the list items.
   </div>
 </template>
 
-<script>
-  const data = sb.init();
-</script>
-
 <body>
-  <user-div sb-mark="user"></user-div>
+  <user-div>
+    <span slot="name" sb-mark="user.name"></span>
+    <span slot="age" sb-mark="user.age"></span>
+  </user-div>
 </body>
 
 <script>

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ and Failures are printed in the console.
 
 See [`test.html`](https://github.com/18alantom/strawberry/blob/main/tests/test.html) for an example.
 
+To see all tests in one place, open `test/index.html`.
+
 ---
 
 ## Douglas Crockford on the XML of today

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,16 +16,100 @@ cost of not being able to do _everything_.
 
 **List**
 
-- [ ] [Nested Components](#nested-components)
 - [ ] [Setting `sb-*` props for Strawberry inserted elements](#setting-sb--props-for-strawberry-inserted-elements)
 - [ ] [Two-way Binding](#two-way-binding)
 - [ ] [Directives for Strawberry Created Elements](#directives-for-strawberry-created-elements)
 - [ ] [Logic Encapsulation in Templates](#logic-encapsulation-in-templates)
 - [ ] [Interactive Elements in Templates](#interactive-elements-in-templates)
 - [ ] [Animating `sb-if`](#animating-sb-if)
+- [x] [Nested Components](#done-nested-components)
 - [x] [Defer Directives](#done-defer-ui-updates)
 
-# Nested Components
+# Setting `sb-*` props for Strawberry inserted elements
+
+**Problem** if I have a list of `a` elements which is added by strawberry
+
+```html
+<!-- Invalid strawberry but gets the point across -->
+<div sb-mark="links" sb-child="a"></div>
+<script>
+  data.a = [{ name: 'Example', link: 'example.com' }];
+</script>
+```
+
+there is no way to set the `href` attribute.
+
+A **Solution** to this is to have a directive that sets attributes. This along
+with the nested components is a solution.
+
+```html
+<div sb-mark="links" sb-child="a">
+  <a sb-mark="links.#.name" sb-attr-href="links.#.link"></a>
+</div>
+<script>
+  data.a = [{ name: 'Example', link: 'example.com' }];
+</script>
+```
+
+# Two-way Binding
+
+**Problem** is `sb-mark` can't be used on input elements to change their
+value when the RDO prop changes, or vice versa.
+
+**Solution** is writing a new directive for this is trivial `sb-model` but the question is
+
+1. Should this be in strawberry?
+2. Should this be incorporated into `sb-mark` when element is an input element?
+
+# Directives for Strawberry Created Elements
+
+**Problem** is when an element is created and inserted by strawberry, there is
+no way to init the properties of that element.
+
+This is more of a enhancement than an issue, should strawberry even do this.
+
+# Logic Encapsulation in Templates
+
+**Problem** is that scripts inside templates run in the global context. And if
+the template is external, they don't run.
+
+This means that templates can't have logic ascribed to them.
+
+# Interactive Elements in Templates
+
+**Problem** is that templates can have multiple interactive elements, inputs,
+buttons, etc. But accessing these elements requires traversing the Shadow DOM.
+
+# Animating `sb-if`
+
+**Problem** is that when `sb-if` causes a elements to be removed it's done using
+`el.replaceWith` which is not animatable.
+
+# `[DONE]` Defer UI updates
+
+**Problem** is that currently when an RDO prop is set in a regular `script` tag
+
+```html
+<script>
+  const data = sb.init();
+  data.prop = 'value';
+</script>
+```
+
+only the elements before the script with the apt `sb-mark` are updated.
+Downstream elements are not updated.
+
+**Desired behavior** is that all elements are updated. Irrespective of the
+where the script is loaded.
+
+A **solution** is that when RDO props are set inside the `head` tag, the updates
+are deferred until the ready state changes to `"interactive"`. This happens only
+after the DOM has been parsed but before all assets have been fetched.
+
+
+# `[DONE]` Nested Components
+
+[PR #9](https://github.com/18alantom/strawberry/pull/9)
 
 **Problem** is that currently `sb-mark` on plain elements don't support nesting.
 For instance say I have a nested list:
@@ -108,84 +192,3 @@ they can be marked like so:
 ```
 
 _Note: this prevents `"#"` from being used as a valid RDO prop name._
-
-# Setting `sb-*` props for Strawberry inserted elements
-
-**Problem** if I have a list of `a` elements which is added by strawberry
-
-```html
-<!-- Invalid strawberry but gets the point across -->
-<div sb-mark="links" sb-child="a"></div>
-<script>
-  data.a = [{ name: 'Example', link: 'example.com' }];
-</script>
-```
-
-there is no way to set the `href` attribute.
-
-A **Solution** to this is to have a directive that sets attributes. This along
-with the nested components is a solution.
-
-```html
-<div sb-mark="links" sb-child="a">
-  <a sb-mark="links.#.name" sb-attr-href="links.#.link"></a>
-</div>
-<script>
-  data.a = [{ name: 'Example', link: 'example.com' }];
-</script>
-```
-
-# Two-way Binding
-
-**Problem** is `sb-mark` can't be used on input elements to change their
-value when the RDO prop changes, or vice versa.
-
-**Solution** is writing a new directive for this is trivial `sb-model` but the question is
-
-1. Should this be in strawberry?
-2. Should this be incorporated into `sb-mark` when element is an input element?
-
-# Directives for Strawberry Created Elements
-
-**Problem** is when an element is created and inserted by strawberry, there is
-no way to init the properties of that element.
-
-This is more of a enhancement than an issue, should strawberry even do this.
-
-# Logic Encapsulation in Templates
-
-**Problem** is that scripts inside templates run in the global context. And if
-the template is external, they don't run.
-
-This means that templates can't have logic ascribed to them.
-
-# Interactive Elements in Templates
-
-**Problem** is that templates can have multiple interactive elements, inputs,
-buttons, etc. But accessing these elements requires traversing the Shadow DOM.
-
-# Animating `sb-if`
-
-**Problem** is that when `sb-if` causes a elements to be removed it's done using
-`el.replaceWith` which is not animatable.
-
-# `[DONE]` Defer UI updates
-
-**Problem** is that currently when an RDO prop is set in a regular `script` tag
-
-```html
-<script>
-  const data = sb.init();
-  data.prop = 'value';
-</script>
-```
-
-only the elements before the script with the apt `sb-mark` are updated.
-Downstream elements are not updated.
-
-**Desired behavior** is that all elements are updated. Irrespective of the
-where the script is loaded.
-
-A **solution** is that when RDO props are set inside the `head` tag, the updates
-are deferred until the ready state changes to `"interactive"`. This happens only
-after the DOM has been parsed but before all assets have been fetched.

--- a/index.ts
+++ b/index.ts
@@ -619,6 +619,10 @@ function initializeArrayElements(
   const prefix = placeholderKey.slice(0, -2); // remove '.#' loop indicator
   const arrayElements: Element[] = [];
   for (const idx in array) {
+    if (Number.isNaN(+idx)) {
+      continue;
+    }
+
     const clone = placeholder.cloneNode(true);
     if (!(clone instanceof Element)) {
       continue;

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,58 @@
+<style>
+  html {
+    background-color: black;
+    font-family: sans-serif;
+    padding: 1rem;
+  }
+
+  a {
+    font-size: 1.5rem;
+    text-transform: capitalize;
+    margin-bottom: 0.5rem;
+    text-decoration: none;
+    color: lightcoral;
+  }
+
+  a:after {
+    content: ' →';
+  }
+
+  a:visited {
+    color: lightcoral;
+  }
+
+  iframe {
+    border: 1px solid lightblue;
+    width: calc(300px + 2rem + 6px);
+    height: calc(128px + 2rem + 6px);
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+  }
+</style>
+<div style="display: flex; flex-wrap: wrap; gap: 2rem">
+  <section>
+    <a href="./test.html">general</a>
+    <iframe src="./test.html"></iframe>
+  </section>
+  <section>
+    <a href="./test.templates.html">templates</a>
+    <iframe src="./test.templates.html"></iframe>
+  </section>
+  <section>
+    <a href="./test.loops.html">loops</a>
+    <iframe src="./test.loops.html"></iframe>
+  </section>
+  <section>
+    <a href="./test.defer.html">defer</a>
+    <iframe src="./test.defer.html"></iframe>
+  </section>
+</div>
+<!-- 
+TODO: Tests:
+- [ ] Custom Handlers
+- [ ] Custom Prefix
+- [ ] Template and Loop tests
+ -->

--- a/tests/test.css
+++ b/tests/test.css
@@ -22,7 +22,7 @@ main > div {
 
 main {
   border: 3px solid rgb(219, 126, 155);
-  width: fit-content;
+  width: 300px;
   margin: 1rem;
 }
 

--- a/tests/test.defer.html
+++ b/tests/test.defer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Sb Test - Defer</title>
     <style>
       html,
       body {
@@ -27,7 +27,7 @@
   </head>
   <body>
     <main>
-      <h1>Sb - Templates Test</h1>
+      <h1>Defer Tests</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>

--- a/tests/test.html
+++ b/tests/test.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Strawberry - Test</title>
+    <title>Sb Test - General</title>
     <script src="../index.js"></script>
     <link rel="stylesheet" href="test.css" />
     <script src="./test.js"></script>
@@ -16,7 +16,7 @@
   </template>
   <body>
     <main>
-      <h1>Sb - General Test</h1>
+      <h1>General Tests</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>
@@ -206,13 +206,15 @@
       delete data.a;
     </script>
 
-    <div id="l1" sb-mark="l1" sb-child="red-p"></div>
+    <div id="l1">
+      <red-p sb-mark="l1.#"></red-p>
+    </div>
     <script>
       const l1 = document.getElementById('l1');
-      test(l1.childElementCount === 0, 'div#l1 has no children');
+      test(l1.childElementCount === 1, 'div#l1 has one child');
 
       data.l1 = ['a'];
-      test(l1.childElementCount === 1, 'div#l1 has one child');
+      test(l1.childElementCount === 2, 'div#l1 has two children');
       test(l1.children[0]?.innerText === 'a', 'div#l1 child 0 is a');
       test(
         l1.children[0]?.tagName.toLowerCase() === 'red-p',
@@ -220,32 +222,38 @@
       );
 
       data.l1.push('b');
-      test(l1.childElementCount === 2, 'div#l1 has two children');
+      test(l1.childElementCount === 3, 'div#l1 has three children');
       test(l1.children[1]?.innerText === 'b', 'div#l1 child 1 is b');
 
       data.l1.pop();
-      test(l1.childElementCount === 1, 'div#l1 one child removed');
+      test(l1.childElementCount === 2, 'div#l1 one child removed');
       test(l1.children[0]?.innerText === 'a', 'div#l1 child 0 is a');
 
       const ch0 = l1.children[0];
       data.l1 = ['a'];
       test(ch0 !== l1.children[0], 'div#l1 children replaced');
-
-      delete data.l1;
-      test(!l1.isConnected, 'div#l1 deleted');
+      data.l1 = [];
+      test(
+        l1.children[0] instanceof HTMLTemplateElement,
+        'div#l1 has template child'
+      );
     </script>
 
     <template name="div-user">
       <div>
-        <h1><slot name="name" />notset</h1>
-        <p><slot name="age" />notset</p>
+        <h1><slot name="name" /></h1>
+        <p><slot name="age" /></p>
       </div>
     </template>
     <script>
       sb.register();
     </script>
 
-    <div-user id="du1" sb-mark="user"></div-user>
+    <!-- user mark applied for deletion -->
+    <div-user id="du1" sb-mark="user">
+      <span slot="name" sb-mark="user.name"></span>
+      <span slot="age" sb-mark="user.age"></span>
+    </div-user>
     <script>
       const du1 = document.getElementById('du1');
       const du1div = du1.shadowRoot.children[0];
@@ -253,18 +261,18 @@
 
       const du1h1 = du1div.children[0];
       test(du1h1 instanceof HTMLHeadingElement, 'el#du1 has a h# element');
-      test(du1h1.innerText === 'notset', 'el#du1>h1 content is placeholder');
 
       const du1p = du1div.children[1];
       test(du1p instanceof HTMLParagraphElement, 'el#du1 has a p element');
-      test(du1p.innerText === 'notset', 'el#du1>p content is placeholder');
       test(
-        document.querySelector('[sb-mark="user.name"]') === null,
-        'user.name not set'
+        document.querySelector('[sb-mark="user.name"]') instanceof
+          HTMLSpanElement,
+        'user.name el is a span'
       );
       test(
-        document.querySelector('[sb-mark="user.age"]') === null,
-        'user.age not set'
+        document.querySelector('[sb-mark="user.age"]') instanceof
+          HTMLSpanElement,
+        'user.age el is a span'
       );
 
       data.user = {};
@@ -290,28 +298,29 @@
 
       data.user = { name: 'TEST', age: 55 };
       test(du1.isConnected, 'el#du1 still connected after reassign');
-      test(du1.children.length === 2, 'el#du1 has two children after reset');
+      test(du1.children.length === 1, 'el#du1 has only one child after reset');
       test(
         du1.children[0].innerText === 'TEST',
         'new user.name span has updated text'
-      );
-      test(
-        du1.children[1].innerText === '55',
-        'new user.age span has updated text'
       );
 
       delete data.user;
       test(!du1.isConnected, 'el#du1 disconnected after user delete');
     </script>
 
-    <div sb-mark="users" sb-child="div-user" id="d1"></div>
+    <div id="d1">
+      <div-user sb-mark="users.#">
+        <span slot="name" sb-mark="users.#.name"></span>
+        <span slot="age" sb-mark="users.#.age"></span>
+      </div-user>
+    </div>
     <script>
       const d1 = document.getElementById('d1');
       data.users = [];
-      test(d1.children.length === 0, 'el#d1 has no children');
+      test(d1.children.length === 1, 'el#d1 has one child');
 
       data.users.push({ name: 'A', age: 1 });
-      test(d1.children.length === 1, 'el#d1 has one child');
+      test(d1.children.length === 2, 'el#d1 has two children');
       test(
         d1.children[0].children[0].innerText === 'A',
         'el#d1[0][0] innerText is A'
@@ -322,7 +331,7 @@
       );
 
       data.users.push({ name: 'B', age: 2 });
-      test(d1.children.length === 2, 'el#d1 has two children');
+      test(d1.children.length === 3, 'el#d1 has three children');
       test(
         d1.children[0].children[0].innerText === 'A',
         'el#d1[0][0] innerText is still A'
@@ -339,37 +348,43 @@
         d1.children[1].children[1].innerText === '2',
         'el#d1[1][1] innerText is 1'
       );
-      delete data.users;
+      data.users = [];
     </script>
 
     <template name="inv-item">
-      <slot name="name" />
+      <p>
+        <slot name="name"></slot>
+      </p>
     </template>
+
     <script>
       sb.register();
     </script>
-    <div id="inv-items" sb-mark="items" sb-child="inv-item"></div>
+
+    <div id="inv-items">
+      <inv-item sb-mark="items.#">
+        <span slot="name" sb-mark="items.#.name"></span>
+      </inv-item>
+    </div>
+
     <script>
       const items = document.getElementById('inv-items');
       data.qtys = {};
+
       data.items = () =>
         Object.keys(data.qtys).map((name) => ({
           name,
           quantity: data.qtys[name],
         }));
 
-      test(items.children.length === 0, 'el#inv-items has no children');
+      test(items.children.length === 1, 'el#inv-items has one child');
       data.qtys['item'] = 0;
-      test(items.children.length === 1, 'el#inv-items has 1 child');
-      test(items.children[0].innerText === 'item', 'el#inv-items has correct innertext');
-      delete data.items;
-      delete data.qtys;
+
+      test(items.children.length === 2, 'el#inv-items has 1 child');
+      test(
+        items.children[0].innerText === 'item',
+        'el#inv-items has correct innerText'
+      );
     </script>
   </body>
-  <!-- 
-    TODO: Tests
-    - [ ] Custom Handlers
-    - [ ] Custom Prefix
-    - [ ] Nested Components, with inner mark and update
-   -->
 </html>

--- a/tests/test.loops.html
+++ b/tests/test.loops.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sb Test - Loops</title>
+    <style>
+      html,
+      body {
+        margin: 0px;
+        background-color: rgb(0, 0, 0);
+        color: white;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+    </style>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="test.css" />
+    <script src="./test.js"></script>
+  </head>
+  <body>
+    <main>
+      <h1>Loop Tests</h1>
+      <div>
+        <p>Success: <span id="success">0</span></p>
+        <p>Failure: <span id="failure">0</span></p>
+        <p>Total: <span id="total">0</span></p>
+      </div>
+    </main>
+    <script>
+      const data = sb.init();
+    </script>
+
+    <!-- List of Primitives -->
+    <ul id="ul1">
+      <li sb-mark="one.#">placeholder</li>
+    </ul>
+    <script>
+      const ul1 = document.getElementById('ul1');
+      test(
+        ul1.children[0] instanceof HTMLLIElement,
+        'ul has placeholder li element'
+      );
+
+      data.one = [];
+      test(
+        ul1.children[0] instanceof HTMLTemplateElement,
+        'ul placeholder in template'
+      );
+
+      data.one.push('one');
+      test(
+        ul1.children[0] instanceof HTMLLIElement,
+        'ul[0] is an li element (no for)'
+      );
+      test(
+        ul1.children[0].innerText === 'one',
+        `ul[0] innerText is "one" (no for)`
+      );
+
+      data.one.push('two', 'three', 'four');
+      test(data.one.length === 4, 'one has 4 items');
+      test(
+        ul1.childElementCount === data.one.length + 1,
+        'ul has one additional element for placeholder'
+      );
+
+      for (const idx in data.one) {
+        test(
+          ul1.children[idx] instanceof HTMLLIElement,
+          `ul[${idx}] is an li element`
+        );
+        test(
+          ul1.children[idx].innerText === data.one[idx],
+          `ul[${idx}] innerText is "${data.one[idx]}"`
+        );
+      }
+
+      data.one.pop();
+      test(
+        ul1.lastElementChild.previousElementSibling.innerText === 'three',
+        'last element "three" after pop'
+      );
+
+      data.one.push('four');
+      test(
+        ul1.lastElementChild.previousElementSibling.innerText === 'four',
+        'last element "four" after push'
+      );
+
+      data.one.shift();
+      test(
+        ul1.firstElementChild.innerText === 'two',
+        'first element "two" after shift'
+      );
+
+      data.one.unshift('one');
+      test(
+        ul1.firstElementChild.innerText === 'one',
+        'first element "one" after unshift'
+      );
+
+      data.one.splice(1, 2, '1', '2');
+      test(
+        ul1.children[1].innerText === '1',
+        'ul[1] innerText "1" after splice'
+      );
+      test(
+        ul1.children[2].innerText === '2',
+        'ul[2] innerText "2" after splice'
+      );
+      test(
+        ul1.childElementCount === 5,
+        '5 children after splice delete 2 add 2'
+      );
+
+      data.one[0] = '0';
+      test(ul1.children[0].innerText === '0', 'ul[0] innerText "0" after set');
+
+      data.one[3] = '3';
+      test(ul1.children[3].innerText === '3', 'ul[0] innerText "0" after set');
+
+      data.one = [];
+      test(ul1.childElementCount === 1, '1 child after empty list set');
+    </script>
+
+    <!-- List of Objects -->
+    <ul id="ul2">
+      <li sb-mark="two.#">
+        <span sb-mark="two.#.a"></span>
+        <span sb-mark="two.#.b"></span>
+      </li>
+    </ul>
+
+    <script>
+      const ul2 = document.getElementById('ul2');
+      test(
+        ul2.children[0] instanceof HTMLLIElement,
+        'ul2 has placeholder li element'
+      );
+      test(ul2.children[0].childElementCount === 2, 'ul2 li has 2 children');
+
+      data.two = [];
+      test(
+        ul2.children[0] instanceof HTMLTemplateElement,
+        'u2 placeholder in template'
+      );
+
+      data.two.push({ a: '0.a', b: '0.b' });
+      test(
+        ul2.children[0]?.children[0].innerText === '0.a',
+        'ul[0][0] innerText is "0.a"'
+      );
+
+      data.two.push(
+        { a: '1.a', b: '1.b' },
+        { a: '2.a', b: '2.b' },
+        { a: '3.a', b: '3.b' }
+      );
+
+      test(data.two.length === 4, 'two has 4 items');
+      test(
+        ul2.childElementCount === data.two.length + 1,
+        'ul has one additional element for placeholder'
+      );
+
+      for (const idx in data.two) {
+        test(
+          ul2.children[idx].children[0].innerText === `${idx}.a`,
+          `ul[${idx}][0] innerText is "${idx}.a"`
+        );
+        test(
+          ul2.children[idx].children[1].innerText === `${idx}.b`,
+          `ul[${idx}][1] innerText is "${idx}.b"`
+        );
+      }
+
+      data.two.pop();
+      test(
+        ul2.lastElementChild.previousElementSibling.firstElementChild
+          .innerText === '2.a',
+        'last element first child "2.a" after pop'
+      );
+
+      data.two.push({ a: '3.a', b: '3.b' });
+      test(
+        ul2.lastElementChild.previousElementSibling.firstElementChild
+          .innerText === '3.a',
+        'last element first child "3.a" after push'
+      );
+
+      data.two.shift();
+      test(
+        ul2.firstElementChild.firstElementChild.innerText === '1.a',
+        'first element first child "1.a" after shift'
+      );
+
+      data.two.unshift({ a: '0.a', b: '0.b' });
+      test(
+        ul2.firstElementChild.firstElementChild.innerText === '0.a',
+        'first element first child "0.a" after unshift'
+      );
+
+      data.two.splice(1, 2, { a: 'x', b: 'y' });
+      test(
+        ul2.children[1].firstElementChild.innerText === 'x',
+        'ul2[1][0] innerText "x" after splice'
+      );
+      test(
+        ul2.children[2].firstElementChild.innerText === '3.a',
+        'ul[2][0] innerText "3.a" after splice'
+      );
+      test(
+        ul2.childElementCount === 4,
+        '5 children after splice delete 2 add 1'
+      );
+
+      data.two[0].a = '0';
+      test(
+        ul2.children[0].firstElementChild.innerText === '0',
+        'ul[0][0] innerText "0" after set'
+      );
+      test(
+        ul2.children[0].children[1].innerText === '0.b',
+        'ul[0][1] innerText remains "0.b" after set'
+      );
+
+      data.two[0].b = '0';
+      test(
+        ul2.children[0].firstElementChild.innerText === '0',
+        'ul[0][0] innerText "0" after set'
+      );
+      test(
+        ul2.children[0].children[1].innerText === '0',
+        'ul[0][1] innerText "0.b" after set'
+      );
+
+      data.two = [];
+      test(ul2.childElementCount === 1, '1 child after empty list set');
+    </script>
+
+    <!-- List of Lists -->
+    <div id="div1">
+      <p sb-mark="three.#">
+        <span sb-mark="three.#.#">placeholder</span>
+      </p>
+    </div>
+
+    <script>
+      data.three = [];
+      data.three.push([]);
+      data.three[0].push(1, 2, 3, 4);
+
+      data.three.push([]);
+      data.three[1].push('a', 'b', 'c', 'd');
+
+      const div1 = document.getElementById('div1');
+      test(div1.childElementCount === 3, 'div1 has 3 children');
+      for (let i in data.three) {
+        for (let j in data.three[i]) {
+          test(
+            div1.children[i].children[j].innerText === String(data.three[i][j]),
+            `div1[${i}][${j}] is ${data.three[i][j]}`
+          );
+        }
+      }
+
+      data.three[0].pop();
+      test(
+        div1.children[0].childElementCount === 4,
+        'div1[0] has 4 children after pop'
+      );
+      test(
+        div1.children[1].childElementCount === 5,
+        'div1[0] still has 5 children'
+      );
+
+      data.three[1] = [];
+      test(
+        div1.children[1].childElementCount === 1,
+        'div1[0] has 1 child after empty list set'
+      );
+
+      data.three.shift();
+      test(div1.childElementCount === 2, 'div1[0] has 2 children after shift');
+
+      data.three.pop();
+      test(div1.childElementCount === 1, 'div1[0] has 1 child after pop');
+    </script>
+  </body>
+</html>

--- a/tests/test.templates.html
+++ b/tests/test.templates.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Sb Test - Templates</title>
     <style>
       html,
       body {
@@ -27,7 +27,7 @@
   </head>
   <body>
     <main>
-      <h1>Sb - Templates Test</h1>
+      <h1>Template Tests</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>


### PR DESCRIPTION
Reference: [ROADMAP.md#nested-components](https://github.com/18alantom/strawberry/blob/9f7570f7418af15b65a22e8463e6ea5a0c8fff18/ROADMAP.md#nested-components)

TLDR:
```html
<!-- List of Objects including Other Lists -->
<div sb-mark="list.#">
  <p sb-mark="list.#.name"></p>

  <!-- Nested List -->
  <div sb-mark="list.#.sublist.#">
    <p sb-mark="list.#.sublist.#.name"></p>
  </div>
</div>

<script>
  data.list = [
    { name: 'one', sublist: [ { name: 'one.one' } ] }
  ]
</script>
```

It also refactors the usage of components to be more _native_ instead of relying brittle shim code.