### PR TITLE
Change magic keys to symbols

### DIFF
--- a/tests/test.computed.html
+++ b/tests/test.computed.html
@@ -74,14 +74,6 @@
         );
       }
 
-      data.a = [1, 2, 3, 4];
-      data.b = () => data.a;
-      test(
-        data.b.__sb_prefix === undefined,
-        'computed values do not return prefixed object'
-      );
-      test(data.a.__sb_prefix === 'a', 'a value proxy unchanged');
-
       data.a = 'hello';
       data.b = async () => data.a.toUpperCase() + ' WORLD';
       data.b.then((v) => {
@@ -113,7 +105,6 @@
 
       test(data.y.length === 1, 'y is filtered version of x');
       test(data.y[0] !== data.x[0], 'y[0] is a clone of x[0]');
-      test(data.y[0].__sb_prefix === undefined, 'y[0] is not prefixed');
       data.d = '';
     </script>
 

--- a/tests/test.html
+++ b/tests/test.html
@@ -27,7 +27,6 @@
       test(typeof sb === 'object', 'sb is function');
 
       const data = sb.init();
-      test('__sb_prefix' in data, 'data is sb magic');
       test(typeof sb.watch === 'function', 'sb.watch is function');
       test(typeof sb.unwatch === 'function', 'sb.unwatch is function');
       test(typeof sb.register === 'function', 'sb.register is function');


### PR DESCRIPTION
Flip magic keys over to symbols. Basically v2 of #18. Affects `__sb_prefix` and `DONT_CALL`.

Let me know if I missed anything.