### PR TITLE
allow global styles in components

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Zero-dependency, build-free framework for the artisanal web.
 
 > **Warning**
 >
-> Strawberry is in a very experimental phase; pre-alpha. Everything stated below
-> works, but I am still figuring out the quickest and cleanest ways of doing
-> things.
+> Strawberry is in an experimental phase. Everything stated below works, but I
+> am still figuring out the quickest and cleanest ways of doing things.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -1123,7 +1123,15 @@ function registerComponent(template: HTMLTemplateElement) {
     constructor() {
       super();
       const shadowRoot = this.attachShadow({ mode: 'open' });
-      for (const ch of template.content.children) {
+      for (const style of document.getElementsByTagName('style')) {
+        shadowRoot.appendChild(style.cloneNode(true));
+      }
+
+      for (const link of document.querySelectorAll('link[rel="stylesheet"]')) {
+        shadowRoot.appendChild(link.cloneNode(true));
+      }
+
+      for (const ch of template.content.childNodes) {
         if (!ch) {
           continue;
         }

--- a/tests/test.html
+++ b/tests/test.html
@@ -38,7 +38,7 @@
       data.y = () => data.x + 5;
       test(data.y === 15, 'y (computed) set on data');
 
-      const rp = document.createElement('red-p').shadowRoot?.children[0];
+      const rp = document.createElement('red-p').shadowRoot?.lastElementChild
       test(rp instanceof HTMLParagraphElement, 'el red-p has p shadowRoot');
       test(rp.style.color === 'red', 'red-p has style.color red');
 
@@ -72,7 +72,7 @@
       test(gp === undefined, 'green-p not registered');
 
       sb.register();
-      gp = document.createElement('green-p').shadowRoot?.children[0];
+      gp = document.createElement('green-p').shadowRoot?.lastElementChild;
       test(gp instanceof HTMLParagraphElement, 'el green-p has p shadowRoot');
       test(gp.style.color === 'green', 'green-p has style.color green');
     </script>
@@ -258,7 +258,7 @@
     </div-user>
     <script>
       const du1 = document.getElementById('du1');
-      const du1div = du1.shadowRoot.children[0];
+      const du1div = du1.shadowRoot.lastElementChild;
       test(du1div instanceof HTMLDivElement, 'el#du1 has shadowRoot div');
 
       const du1h1 = du1div.children[0];


### PR DESCRIPTION
Closes #17 

The only way to make templates inherit globally available CSS is by appending the respective styles into the `shadowRoot` of the created element. This turns out is the [recommended way](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#internal_vs._external_styles).

From the page:

> Many modern browsers implement an optimization for [<style>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style) tags either cloned from a common node or that have identical text, to allow them to share a single backing stylesheet. With this optimization the performance of external and internal styles should be similar.