### PR TITLE
add ESM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /index.js
+/index.esm.js
 /index.html
 /perf.html
 /temp

--- a/dist.sh
+++ b/dist.sh
@@ -11,18 +11,29 @@ mkdir dist
 
 version=$(cat package.json | grep '"version"' | cut -d'"' -f4)
 file_path="dist/sb.min.js"
+file_path_esm="dist/sb.min.esm.js"
+
 file_header="/* Strawberry $version
  * Copyright (c) 2023-present, Alan Tom (18alantom)
  * MIT License
  * This is a generated file. Do not edit.*/"
 
 echo "$file_header" >> "$file_path"
+echo "$file_header" >> "$file_path_esm"
+
 node_modules/.bin/esbuild ./index.ts --bundle --minify --format=iife --global-name=sb >> "$file_path"
+node_modules/.bin/esbuild ./index.ts --bundle --minify --format=esm >> "$file_path_esm"
 
-size=$(wc -c < $file_path)
-gzsize=$(gzip -c $file_path | wc -c)
+print_done() {
+  size=$(wc -c < $1)
+  gzsize=$(gzip -c $1 | wc -c)
 
-kb=$(echo "scale=3; $size / 1024" | bc)
-gzkb=$(echo "scale=3; $gzsize / 1024" | bc)
+  kb=$(echo "scale=3; $size / 1024" | bc)
+  gzkb=$(echo "scale=3; $gzsize / 1024" | bc)
 
-echo "dist/sb.min.js is ${kb}KB and gzipped ${gzkb}KB"
+  path=$(printf "%-18s" $1)
+  echo "$path :: size: ${kb}KB, gzip: ${gzkb}KB"
+}
+
+print_done $file_path
+print_done $file_path_esm

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,7 @@ This page lists the available strawberry directives and exported methods.
    5. [`register`](#register): register custom components.
    6. [`load`](#load): load components from external files.
    7. [`prefix`](#prefix): change prefix `"sb"` to a custom value.
+   8. [`rdo`](#rdo): returns the reactive data object if initialized.
 
 ## Directives
 
@@ -300,4 +301,37 @@ if you want to use data attributes to manage directives you can do this:
   sb.prefix('data-sb');
 </script>
 <p data-sb-mark="message"></p>
+```
+
+### `rdo`
+
+```typescript
+function rdo(): ReactiveObject | null;
+```
+
+Returns the **r**eactive **d**ata **o**bject if Strawberry has been initialized using
+[`sb.init`](#init).
+
+Useful for when Strawberry is being use as an ESM import where global state is
+not shared across module scripts. Example:
+
+```html
+<script type="module">
+  import { init, rdo } from 'sb';
+  
+  rdo() === null; // evaluates to true
+
+  // Module 1: Initialize Strawberry
+  const data = init();
+  
+  rdo() === data; // evaluates to true
+</script>
+
+<script type="module">
+  import { rdo } from 'sb';
+
+  // Module 2: Get data from `rdo` after init
+  // in Module 1.
+  const data = rdo();
+</script>
 ```

--- a/docs/reactivity/mark.md
+++ b/docs/reactivity/mark.md
@@ -165,3 +165,12 @@ If removing elements from the DOM is not what you intend to happen, you can inst
 > Array items on the other hand can be deleted `delete data.list[0]` but this is
 > not recommended as it will lead to incorrect sequences of keys, instead use 
 > array operations such as `splice`, `pop`, or `shift`.
+
+> **Note**: **Deleting Values in Modules**
+>
+> When using Strawberry as an ESM import. i.e `<script type="module">` deleting
+> a value in the script will cause elements marked with the value bot
+> **before and after** the script tag to be deleted.
+> 
+> This is because module execution is
+> [deferred](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_standard_scripts).

--- a/index.ts
+++ b/index.ts
@@ -1202,6 +1202,14 @@ export function unwatch(key?: string, watcher?: Watcher): void {
 }
 
 /**
+ * Returns reactive data object if sb.init has been called, else
+ * returns null.
+ */
+export function data(): typeof globalData {
+  return globalData;
+}
+
+/**
 
 # Scratch Space
 

--- a/index.ts
+++ b/index.ts
@@ -1205,7 +1205,7 @@ export function unwatch(key?: string, watcher?: Watcher): void {
  * Returns reactive data object if sb.init has been called, else
  * returns null.
  */
-export function data(): typeof globalData {
+export function rdo(): typeof globalData {
   return globalData;
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "dev": "esbuild ./index.ts --bundle --format=iife --global-name=sb --watch --outfile=index.js",
+    "dev-esm": "esbuild ./index.ts --bundle --format=esm --global-name=sb --watch --outfile=index.esm.js",
     "dist": "./dist.sh",
     "pub": "tsc && yarn dist && yarn publish --access public && ./postpub.sh"
   },

--- a/tests/esm/test.html
+++ b/tests/esm/test.html
@@ -34,7 +34,7 @@
       test(typeof sb.watch === 'function', 'sb.watch is function');
       test(typeof sb.unwatch === 'function', 'sb.unwatch is function');
       test(typeof sb.register === 'function', 'sb.register is function');
-      test(data === sb.data(), 'sb returns same data');
+      test(data === sb.rdo(), 'sb returns same data');
 
       data.x = 10;
       test(data.x === 10, 'x (value) set on data');
@@ -53,7 +53,7 @@
     <p id="1" sb-mark="a">notset</p>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       const p1 = document.getElementById('1');
       test(p1.isConnected, 'p#1 connected');
@@ -76,7 +76,7 @@
     </template>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       let gp = document.createElement('green-p').shadowRoot?.lastElementChild;
       test(gp instanceof HTMLParagraphElement, 'el green-p has p shadowRoot');
@@ -87,7 +87,7 @@
     <green-p id="3" sb-mark="j">green</green-p>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       const p2 = document.getElementById('2');
       const p3 = document.getElementById('3');
@@ -119,7 +119,7 @@
     </template>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       test(document.getElementById('4') === null, 'p#4 not found');
 
@@ -154,7 +154,7 @@
     <p id="5" sb-mark="b">notset</p>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       const p5 = document.getElementById('5');
       test(p5.innerText === 'notset', 'p#5 data not set');
@@ -229,7 +229,7 @@
     </div>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       const l1 = document.getElementById('l1');
       test(l1.childElementCount === 1, 'div#l1 has one child');
@@ -273,7 +273,7 @@
     </div-user>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       const du1 = document.getElementById('du1');
       const du1div = du1.shadowRoot.lastElementChild;
@@ -336,7 +336,7 @@
     </div>
     <script type="module">
       import * as sb from 'sb';
-      const data = sb.data();
+      const data = sb.rdo();
 
       const d1 = document.getElementById('d1');
       data.users = [];
@@ -392,8 +392,8 @@
     </div>
 
     <script type="module">
-      import * as sb from 'sb';
-      const data = sb.data();
+      import { rdo } from 'sb';
+      const data = rdo();
 
       const items = document.getElementById('inv-items');
       data.qtys = {};

--- a/tests/esm/test.html
+++ b/tests/esm/test.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sb Test - General</title>
-    <script src="../index.js"></script>
-    <link rel="stylesheet" href="test.css" />
-    <script src="./test.js"></script>
+    <title>Sb Test (ESM) - General</title>
+    <link rel="stylesheet" href="../test.css" />
+    <script src="../test.js"></script>
+    <script type="importmap">
+      { "imports": { "sb": "../../index.esm.js" } }
+    </script>
   </head>
   <template name="red-p">
     <p style="color: red">
@@ -16,21 +18,23 @@
   </template>
   <body>
     <main>
-      <h1>General</h1>
+      <h1>General (ESM)</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>
         <p>Total: <span id="total">0</span></p>
       </div>
     </main>
-    <script>
-      test(typeof sb === 'object', 'sb is function');
+
+    <script type="module">
+      import * as sb from 'sb';
+      test(typeof sb === 'object', 'sb is an object');
 
       const data = sb.init();
       test(typeof sb.watch === 'function', 'sb.watch is function');
       test(typeof sb.unwatch === 'function', 'sb.unwatch is function');
       test(typeof sb.register === 'function', 'sb.register is function');
-      test(data === sb.init(), 'sb returns same data');
+      test(data === sb.data(), 'sb returns same data');
 
       data.x = 10;
       test(data.x === 10, 'x (value) set on data');
@@ -38,7 +42,7 @@
       data.y = () => data.x + 5;
       test(data.y === 15, 'y (computed) set on data');
 
-      const rp = document.createElement('red-p').shadowRoot?.lastElementChild
+      const rp = document.createElement('red-p').shadowRoot?.lastElementChild;
       test(rp instanceof HTMLParagraphElement, 'el red-p has p shadowRoot');
       test(rp.style.color === 'red', 'red-p has style.color red');
 
@@ -47,7 +51,10 @@
     </script>
 
     <p id="1" sb-mark="a">notset</p>
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const p1 = document.getElementById('1');
       test(p1.isConnected, 'p#1 connected');
       test(p1.innerText === 'notset', 'p#1 data not set');
@@ -67,47 +74,53 @@
         <slot />
       </p>
     </template>
-    <script>
-      let gp = document.createElement('green-p').shadowRoot?.children[0];
-      test(gp === undefined, 'green-p not registered');
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
 
-      sb.register();
-      gp = document.createElement('green-p').shadowRoot?.lastElementChild;
+      let gp = document.createElement('green-p').shadowRoot?.lastElementChild;
       test(gp instanceof HTMLParagraphElement, 'el green-p has p shadowRoot');
       test(gp.style.color === 'green', 'green-p has style.color green');
     </script>
 
-    <red-p id="2" sb-mark="a">red</red-p>
-    <green-p id="3" sb-mark="b">green</green-p>
-    <script>
+    <red-p id="2" sb-mark="i">red</red-p>
+    <green-p id="3" sb-mark="j">green</green-p>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const p2 = document.getElementById('2');
       const p3 = document.getElementById('3');
+
       test(p2.tagName.toLowerCase() === 'red-p', 'p#2 is red-p');
-      test(p3.tagName.toLowerCase() === 'green-p', 'p#3 is red-p');
+      test(p3.tagName.toLowerCase() === 'green-p', 'p#3 is green-p');
       test(p2.innerText === 'red', 'p#2 data not set');
       test(p3.innerText === 'green', 'p#3 data not set');
 
-      data.a = 'RED';
-      data.b = 'GREEN';
+      data.i = 'RED';
+      data.j = 'GREEN';
       test(p2.innerText === 'RED', 'p#2 data set');
       test(p3.innerText === 'GREEN', 'p#3 data set');
 
-      data.b = () => data.a.toLowerCase();
+      data.j = () => data.i.toLowerCase();
       test(p3.innerText === 'red', 'p#3 data computed');
 
-      data.a = 'GREEN';
+      data.i = 'GREEN';
       test(p3.innerText === 'green', 'p#3 data set from computed');
 
-      delete data.a;
+      delete data.i;
       test(!p2.isConnected, 'p#2 not connected');
-      delete data.b;
+      delete data.j;
       test(!p3.isConnected, 'p#3 not connected');
     </script>
 
     <template sb-if="a">
       <p id="4">temp</p>
     </template>
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       test(document.getElementById('4') === null, 'p#4 not found');
 
       data.a = false;
@@ -139,7 +152,10 @@
     </script>
 
     <p id="5" sb-mark="b">notset</p>
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const p5 = document.getElementById('5');
       test(p5.innerText === 'notset', 'p#5 data not set');
       data.a = 'stuff';
@@ -211,7 +227,10 @@
     <div id="l1">
       <red-p sb-mark="l1.#"></red-p>
     </div>
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const l1 = document.getElementById('l1');
       test(l1.childElementCount === 1, 'div#l1 has one child');
 
@@ -247,16 +266,15 @@
         <p><slot name="age" /></p>
       </div>
     </template>
-    <script>
-      sb.register();
-    </script>
 
-    <!-- user mark applied for deletion -->
     <div-user id="du1" sb-mark="user">
       <span slot="name" sb-mark="user.name"></span>
       <span slot="age" sb-mark="user.age"></span>
     </div-user>
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const du1 = document.getElementById('du1');
       const du1div = du1.shadowRoot.lastElementChild;
       test(du1div instanceof HTMLDivElement, 'el#du1 has shadowRoot div');
@@ -316,7 +334,10 @@
         <span slot="age" sb-mark="users.#.age"></span>
       </div-user>
     </div>
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const d1 = document.getElementById('d1');
       data.users = [];
       test(d1.children.length === 1, 'el#d1 has one child');
@@ -359,7 +380,8 @@
       </p>
     </template>
 
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
       sb.register();
     </script>
 
@@ -369,7 +391,10 @@
       </inv-item>
     </div>
 
-    <script>
+    <script type="module">
+      import * as sb from 'sb';
+      const data = sb.data();
+
       const items = document.getElementById('inv-items');
       data.qtys = {};
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -31,11 +31,21 @@
     display: flex;
     flex-direction: column;
   }
+  
+  h1 {
+    color: white;
+    font-size: 4rem;
+  }
 </style>
+<h1>Strawberry Tests</h1>
 <div style="display: flex; flex-wrap: wrap; gap: 2rem">
   <section>
     <a href="./test.html">general</a>
     <iframe src="./test.html"></iframe>
+  </section>
+  <section>
+    <a href="./esm/test.html">general (ESM)</a>
+    <iframe src="./esm/test.html"></iframe>
   </section>
   <section>
     <a href="./test.templates.html">templates</a>

--- a/tests/test.computed.html
+++ b/tests/test.computed.html
@@ -17,7 +17,7 @@
     </script>
 
     <main>
-      <h1>Computed Tests</h1>
+      <h1>Computed</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>

--- a/tests/test.conditionals.html
+++ b/tests/test.conditionals.html
@@ -13,7 +13,7 @@
 
   <body>
     <main>
-      <h1>Conditionals Tests</h1>
+      <h1>Conditionals</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>

--- a/tests/test.directives.html
+++ b/tests/test.directives.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <main>
-      <h1>Directives Tests</h1>
+      <h1>Directives</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>

--- a/tests/test.loops.html
+++ b/tests/test.loops.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <main>
-      <h1>Loop Tests</h1>
+      <h1>Loop</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>

--- a/tests/test.templates.html
+++ b/tests/test.templates.html
@@ -18,7 +18,7 @@
   </head>
   <body>
     <main>
-      <h1>Template Tests</h1>
+      <h1>Template</h1>
       <div>
         <p>Success: <span id="success">0</span></p>
         <p>Failure: <span id="failure">0</span></p>


### PR DESCRIPTION
Allow `sb` to be used as an ESM import.

Example:
```html
<head>
    <script type="importmap">
      { "imports": { "sb": "./sb.esm.js" } }
    </script>
</head>
<script type="module">
    import * as sb from 'sb';

    const data = sb.init();
</script>
```
